### PR TITLE
Fix: ServiceAccountStaticAccessKey resource was not created due to incorrect external-name configuration

### DIFF
--- a/config/external_name.go
+++ b/config/external_name.go
@@ -20,7 +20,7 @@ var ExternalNameConfigs = map[string]config.ExternalName{
 	"yandex_iam_service_account_api_key":                      config.NameAsIdentifier,
 	"yandex_iam_service_account_iam_policy":                   config.NameAsIdentifier,
 	"yandex_iam_service_account_iam_binding":                  config.NameAsIdentifier,
-	"yandex_iam_service_account_static_access_key":            config.NameAsIdentifier,
+	"yandex_iam_service_account_static_access_key":            config.IdentifierFromProvider,
 	"yandex_iam_service_account_iam_member":                   config.NameAsIdentifier,
 	"yandex_organizationmanager_group":                        config.IdentifierFromProvider,
 	"yandex_organizationmanager_group_iam_member":             config.IdentifierFromProvider,

--- a/internal/controller/iam/serviceaccountstaticaccesskey/zz_controller.go
+++ b/internal/controller/iam/serviceaccountstaticaccesskey/zz_controller.go
@@ -31,7 +31,6 @@ import (
 func Setup(mgr ctrl.Manager, o tjcontroller.Options) error {
 	name := managed.ControllerName(v1alpha1.ServiceAccountStaticAccessKey_GroupVersionKind.String())
 	var initializers managed.InitializerChain
-	initializers = append(initializers, managed.NewNameAsExternalName(mgr.GetClient()))
 	cps := []managed.ConnectionPublisher{managed.NewAPISecretPublisher(mgr.GetClient(), mgr.GetScheme())}
 	if o.SecretStoreConfigGVK != nil {
 		cps = append(cps, connection.NewDetailsManager(mgr.GetClient(), *o.SecretStoreConfigGVK, connection.WithTLSConfig(o.ESSOptions.TLSConfig)))


### PR DESCRIPTION
### Description of your changes
Changed ServiceAccountStaticAccessKey resource external-name configuration

### Fixes
ServiceAccountStaticAccessKey resource was not created due to incorrect external-name configuration

I have:
- [x] Run `make reviewable test` to ensure this PR is ready for review.
