### PR TITLE
Fix: High Read Requests Rate for Crossplane Provider Bucket Resource

### DIFF
--- a/apis/storage/v1alpha1/zz_bucket_terraformed.go
+++ b/apis/storage/v1alpha1/zz_bucket_terraformed.go
@@ -114,6 +114,10 @@ func (tr *Bucket) LateInitialize(attrs []byte) (bool, error) {
 		return false, errors.Wrap(err, "failed to unmarshal Terraform state parameters for late-initialization")
 	}
 	opts := []resource.GenericLateInitializerOption{resource.WithZeroValueJSONOmitEmptyFilter(resource.CNameWildcard)}
+	opts = append(opts, resource.WithNameFilter("AnonymousAccessFlags"))
+	opts = append(opts, resource.WithNameFilter("AnonymousAccessFlags.ConfigRead"))
+	opts = append(opts, resource.WithNameFilter("AnonymousAccessFlags.List"))
+	opts = append(opts, resource.WithNameFilter("AnonymousAccessFlags.Read"))
 
 	li := resource.NewGenericLateInitializer(opts...)
 	return li.LateInitialize(&tr.Spec.ForProvider, params)

--- a/config/storage/config.go
+++ b/config/storage/config.go
@@ -37,6 +37,9 @@ func Configure(p *ujconfig.Provider) {
 			Type:      fmt.Sprintf("%s.%s", iam.ApisPackagePath, "ServiceAccountStaticAccessKey"),
 			Extractor: common.ExtractPublicKeyFuncPath,
 		}
+		r.LateInitializer = ujconfig.LateInitializer{
+			IgnoredFields: []string{"anonymous_access_flags", "anonymous_access_flags.config_read", "anonymous_access_flags.list", "anonymous_access_flags.read"},
+		}
 	})
 	p.AddResourceConfigurator("yandex_storage_object", func(r *ujconfig.Resource) {
 		r.UseAsync = true


### PR DESCRIPTION
### Description of your changes


Fixes:
- High Read Requests Rate for Crossplane Provider Bucket Resource

I have:

- [x] Run `make reviewable test` to ensure this PR is ready for review.